### PR TITLE
Fix prompt character input

### DIFF
--- a/src/tools/tools.jl
+++ b/src/tools/tools.jl
@@ -10,8 +10,12 @@ function prompt(io::IO, msg, quiet::Bool=false)
     if quiet
         println(" Yes.")
     else
-        print(" [Y/n]")
-        read(io, Char) in ['Y', 'y', '\n'] || return false
+        print(" [Y/n] ")
+        run(`stty raw`)
+        input = read(io, Char)
+        run(`stty cooked`)
+        println()
+        input in ['Y', 'y', '\n'] || return false
     end
 
     return true

--- a/src/tools/tools.jl
+++ b/src/tools/tools.jl
@@ -14,8 +14,7 @@ function prompt(io::IO, msg, quiet::Bool=false)
         run(`stty raw`)
         input = read(io, Char)
         run(`stty cooked`)
-        println()
-        input in ['Y', 'y', '\n'] || return false
+        input in ['Y', 'y', '\n', '\r'] || return false
     end
 
     return true

--- a/src/tools/tools.jl
+++ b/src/tools/tools.jl
@@ -14,6 +14,7 @@ function prompt(io::IO, msg, quiet::Bool=false)
         run(`stty raw`)
         input = read(io, Char)
         run(`stty cooked`)
+        println()
         input in ['Y', 'y', '\n', '\r'] || return false
     end
 


### PR DESCRIPTION
When using the prompts, the behavior is not correct. If it prompts me to update `PATH`, I have to type `n` and then a carriage return to trigger the `read` to finish. It then reads a character, `n` and on the second prompt asking to update `FPATH`, the read already has another character to read which is the `\n` to finish the previous read. This means to deny the second prompt you must preemptively type `nn\n` on the first question. This changes the tty mode so that it reads the raw character input, prompts, reads a single character, and puts the tty mode back. This fixes this bug and also makes it so you don't have to press return on prompts.