### PR TITLE
Check if entry name is the same as CLI config name

### DIFF
--- a/src/tools/build.jl
+++ b/src/tools/build.jl
@@ -54,7 +54,7 @@ const COMONICON_TOML = ["Comonicon.toml", "JuliaComonicon.toml"]
 function build(mod, sysimg = true; incremental = true, filter_stdlibs = false, kwargs...)
     configs = read_configs(mod; incremental = incremental, filter_stdlibs = filter_stdlibs, kwargs...)
 
-    validate_toml(configs)
+    validate_toml(mod, configs)
     configs = merge_defaults(mod, configs)
 
     if sysimg && !haskey(configs, "sysimg")
@@ -70,7 +70,7 @@ end
 function install(mod; kwargs...)
     configs = read_configs(mod; kwargs...)
     configs = merge_defaults(mod, configs)
-    validate_toml(configs)
+    validate_toml(mod, configs)
     return install(mod, configs)
 end
 
@@ -126,7 +126,13 @@ function merge_defaults(mod, configs)
     return configs
 end
 
-function validate_toml(configs)
+function validate_toml(mod, configs)
+    haskey(configs, "name") || error("missing key \"name\" in Comonicon.toml or kwargs")
+    got = configs["name"]
+    exp = Types.cmd_name(mod.CASTED_COMMANDS["main"])
+    got == exp ||
+        error("field name must be the same with entry name, expect $exp got $got")
+
     _check(configs["install"], "compile") do x
         x in [nothing, "min", "no", "all", "yes"]
     end

--- a/test/build.jl
+++ b/test/build.jl
@@ -76,3 +76,26 @@ end
 @test isfile(PATH.project("test", "Foo", "deps", BuildTools.tarball_name("foo")))
 
 Pkg.rm(PackageSpec(name = "Foo"))
+
+# PR #48: check if the name of entry stays the same as config
+module PR48
+using ..Comonicon
+@cast foo(x) = x
+@cast goo(y) = y
+
+@main name = "PR48"
+
+end
+
+configs = Dict(
+    "name" => "foo",
+    "completion" => true,
+    "quiet" => false,
+    "compile" => "min",
+    "optimize" => 2
+)
+
+
+@testset "#48" begin
+    @test_throws ErrorException Comonicon.BuildTools.validate_toml(PR48, configs)    
+end

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -64,7 +64,7 @@ tick tick.
     @test yy in [1.0, 2.0]
 end
 
-@main name = "main" doc = """
+@main name = "dummy" doc = """
     dummy command. dasdas dsadasdnaskdas dsadasdnaskdas
     sdasdasdasdasdasd adsdasdas dsadasdas dasdasd dasda
     """


### PR DESCRIPTION
This should resolve #48 , the reason why we are not forcing file name to be the one written in config is simply because we might need to provide the flexibility to create alias when there are name conflicts in CLIs, e.g developer could potentially provide alternative file name to install a given command, which is like

file `foo-dark` executes the `foo` command
file `foo` executes another `foo` command

this should make sense. So now we will let people to make sure their file name is the same as entry command name at interface level. The implementation of this part is likely to change due to this feature.

cc: hope this work for you @mehalter 