### PR TITLE
Fix printing of Vararg on Julia 1.7

### DIFF
--- a/src/ast/printing.jl
+++ b/src/ast/printing.jl
@@ -1,5 +1,14 @@
 tab(n::Int) = " "^n
-ignore_type(type) = type in [Any, String] || type <: AbstractString
+
+function is_vararg(T)
+    @static if VERSION < v"1.7"
+        T <: Vararg
+    else
+        typeof(T) == Core.TypeofVararg
+    end
+end		
+
+ignore_type(type) = !is_vararg(type) && (type in [Any, String] || type <: AbstractString)
 
 function has_args(cmd::LeafCommand)
     !isempty(cmd.args) || !isnothing(cmd.vararg)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,6 +23,7 @@ end
     include("frontend/cast.jl")
     include("frontend/markdown.jl")
     include("long_print.jl")
+    include("vararg.jl")
 end
 
 @testset "codegen" begin

--- a/test/vararg.jl
+++ b/test/vararg.jl
@@ -1,0 +1,2 @@
+using Comonicon
+@main foo(xs::Vararg{String}) = foreach(println, xs)


### PR DESCRIPTION
Recent versions of Julia has moved Vararg from being a Type to being its own thing. This means it will error if T is a vararg and you try to do `isa` to `<:` operations with it.
This caused an error, which is fixed here by explicitly testing if T is a Vararg.

Fixes #261 

Note that THIS IS NOT TESTED! I couldn't figure out how to write a test for this.