### PR TITLE
fix: use invokelatest for command_main to fix Julia 1.12 world age error

### DIFF
--- a/src/frontend/cast.jl
+++ b/src/frontend/cast.jl
@@ -461,7 +461,7 @@ end
 function codegen_script_entry(m::Module, line, @nospecialize(ex))
     quote
         $(codegen_create_entry(m, line, ex))
-        command_main()
+        Base.invokelatest(command_main)
     end
 end
 


### PR DESCRIPTION
## Summary

Julia 1.12 introduced stricter world age semantics for global bindings. The `@main` macro's `codegen_script_entry` generates `command_main()` and immediately calls it in the same top-level expression, which triggers a `MethodError` because the method is "too new" for the current world age:

```
WARNING: Detected access to binding `Main.command_main` in a world prior to its definition world.
  Julia 1.12 has introduced more strict world age semantics for global bindings.

ERROR: LoadError: MethodError: no method matching command_main()
The applicable method may be too new: running in world age 38895, while current world is 38898.
```

The fix wraps the call in `Base.invokelatest` as suggested by the Julia warning itself:
> Hint: Add an appropriate `invokelatest` around the access to this binding.

## Change

One-line change in `src/frontend/cast.jl`:
- `command_main()` → `Base.invokelatest(command_main)`