### PR TITLE
fix: render Description.brief when content is empty

### DIFF
--- a/src/ast/printing.jl
+++ b/src/ast/printing.jl
@@ -118,9 +118,9 @@ function _print_dash(io::IO, cmd::Union{Option,Flag}, t::Terminal)
 end
 
 function print_content(io::IO, desc::Description, t::Terminal)
-    isnothing(desc.content) || (print_within(io, desc.content, t.width, 0); return)
+    isempty(desc.content) || (print_within(io, desc.content, t.width, 0); return)
     # if Intro section is empty, use brief description
-    isnothing(desc.brief) || print_within(io, desc.brief, t.width, 0)
+    isempty(desc.brief) || print_within(io, desc.brief, t.width, 0)
 end
 
 function print_cmd(io::IO, cmd::Entry, t::Terminal)

--- a/test/ast/ast.jl
+++ b/test/ast/ast.jl
@@ -61,6 +61,23 @@ node = NodeCommand(; name = "foo", subcmds = Dict("leaf" => leaf))
     "-h, --help" in node
 end
 
+# Regression: a NodeCommand whose Description has a non-empty `brief` but an
+# empty `content` (the default) must render its brief in the intro slot of the
+# help output. Before this fix, `print_content` checked `isnothing(desc.content)`,
+# which was false for the default empty-String "", so the function returned
+# without ever consulting `desc.brief`. Symptom: the docstring directly above
+# `@main` for a multi-command entry was parsed into `brief` and silently
+# discarded, leaving 3 contiguous blank lines between the program name and the
+# `Usage` section.
+brief_only_node = NodeCommand(;
+    name = "brief_only",
+    subcmds = Dict("leaf" => leaf),
+    description = Description("a brief summary of this command tree"),
+)
+@test_show MIME"text/plain" begin
+    "a brief summary of this command tree" in brief_only_node
+end
+
 text = "registry you want to register the package. If the package has not been registered, ion will try to register the package in the General registry. Or the user needs to specify the registry to register using this option."
 
 


### PR DESCRIPTION
## Bug

`print_content(::IO, ::Description, ::Terminal)` (`src/ast/printing.jl:120-124`)
guards the content-vs-brief fallback with `isnothing(desc.content)`. However
`Description.content` and `Description.brief` are declared as
`::String = ""` (`src/ast/types.jl:30-33`) — they are never `Nothing`. The
guard is always false on the default-empty case, so the content branch
unconditionally calls `print_within(io, "", ...)` and returns, leaving
`desc.brief` permanently unreachable.

## User-visible symptom

The docstring placed above `@main` for a multi-command CLI is parsed by
`codegen_multiple_main_entry` (`src/frontend/cast.jl:521-538`) into
`Description.brief` (via the `String -> Description` convert method that
populates brief and leaves content empty), then silently discarded at render
time. The user sees 3 contiguous blank lines between the program name and
the `Usage` section instead of the documented introduction.

Repro:

```julia
module Demo
using Comonicon
@cast f(x) = println(x)
"Introduces the demo CLI."
@main
end
```

Before this patch, `Demo --help` shows three blank lines where the
"Introduces the demo CLI." line should appear.

## Fix

Replace `isnothing` with `isempty` for both `desc.content` and `desc.brief`.
Both fields are typed `String`, so `isempty` is the field-type-appropriate
emptiness check.

## Test

Adds a regression test in `test/ast/ast.jl` that constructs a `NodeCommand`
whose `Description` has only a non-empty `brief` and asserts the brief text
appears in the rendered output. The test fails on `master` and passes with
this fix; the rest of the suite is unaffected.
